### PR TITLE
Implement Kafka streaming producer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,5 @@ DB_PASSWORD=arbitrage_password
 # CLIENT_ID=your_client_id_here
 # CLIENT_SECRET=your_client_secret_here
 # API_ENDPOINT=your_api_endpoint_here
+# Kafka configuration for streaming ingestion
+KAFKA_BOOTSTRAP_SERVERS=kafka:9092

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN chown -R app:app /app
 USER app
 
 # Default command
-CMD ["python", "src/main.py", "--sport", "baseball_mlb"]
+CMD ["python", "src/odds_streaming_producer.py"]

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,4 +8,6 @@ beautifulsoup4
 tzlocal
 psycopg2-binary
 schedule
+# Kafka client for streaming ingestion
+kafka-python
 # Add other dependencies below as needed

--- a/src/odds_streaming_producer.py
+++ b/src/odds_streaming_producer.py
@@ -1,0 +1,35 @@
+import asyncio
+import json
+import os
+from dotenv import load_dotenv, find_dotenv
+from kafka import KafkaProducer
+
+from lib.networkhandler import OddsAPIHandler
+
+# Load environment variables from .env.local and .env as fallback
+load_dotenv(find_dotenv('.env.local'))
+load_dotenv(find_dotenv('.env'))
+
+KAFKA_BOOTSTRAP_SERVERS = os.getenv('KAFKA_BOOTSTRAP_SERVERS', 'kafka:9092')
+SPORT = os.getenv('SPORT', 'baseball_mlb')
+REQUEST_LIMIT = int(os.getenv('REQUEST_LIMIT', 500))
+FETCH_INTERVAL = float(os.getenv('FETCH_INTERVAL', 5))
+TOPIC = 'odds_raw'
+
+async def produce_odds():
+    producer = KafkaProducer(bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS)
+    api = OddsAPIHandler(SPORT)
+    requests_made = 0
+    while requests_made < REQUEST_LIMIT:
+        try:
+            odds_data = await asyncio.to_thread(api.fetch_from_api)
+            producer.send(TOPIC, json.dumps(odds_data).encode('utf-8'))
+            producer.flush()
+            requests_made += 1
+        except Exception as e:
+            print(f"Error fetching or publishing odds: {e}")
+        await asyncio.sleep(FETCH_INTERVAL)
+    print("Request limit reached, stopping producer")
+
+if __name__ == '__main__':
+    asyncio.run(produce_odds())


### PR DESCRIPTION
## Summary
- install `kafka-python`
- add `KAFKA_BOOTSTRAP_SERVERS` env var example
- run odds ingestion via new `odds_streaming_producer` script

## Testing
- `pytest -q` *(fails: ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_688912c40bf483248c24e176b94e9ee9